### PR TITLE
feat: added http blocking send method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,10 +15,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
+name = "bytes"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "hashbrown"
@@ -33,6 +45,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
@@ -150,6 +173,8 @@ dependencies = [
 name = "ssdk-http"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "http",
  "wit-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
+anyhow = { version = "1.0" }
+
 wit-bindgen = { version = "0.16.0" }
 

--- a/crates/ssdk-http/Cargo.toml
+++ b/crates/ssdk-http/Cargo.toml
@@ -7,4 +7,7 @@ repository = "https://github.com/infinyon/ssdk"
 description = "SSDK Http API for WASI targets"
 
 [dependencies]
+anyhow = { workspace = true }
+http = { version = "1.0.0" }
+
 wit-bindgen = { workspace = true, features = ['default'] }

--- a/crates/ssdk-http/src/lib.rs
+++ b/crates/ssdk-http/src/lib.rs
@@ -1,6 +1,158 @@
-pub mod bindings {
+pub mod http {
+    pub use http::*;
+}
+
+use anyhow::anyhow;
+pub type Result<T> = anyhow::Result<T>;
+pub type Error = anyhow::Error;
+
+mod bindings {
     wit_bindgen::generate!({
         path: "wit",
         world: "http",
     });
+}
+
+pub mod blocking {
+    use anyhow::anyhow;
+
+    use crate::bindings::wasi::http::outgoing_handler;
+    use crate::bindings::wasi::http::types::{OutgoingBody, OutgoingRequest};
+    use crate::bindings::wasi::io::streams::StreamError;
+
+    use super::http::{Request, Response};
+    use super::Result;
+
+    pub fn send<T: AsRef<[u8]>>(request: Request<T>) -> Result<Response<Vec<u8>>> {
+        let request_wasi = OutgoingRequest::try_from(&request)?;
+
+        let request_body = request_wasi
+            .body()
+            .map_err(|_| anyhow!("outgoing request write failed"))?;
+        let output_stream = request_body
+            .write()
+            .map_err(|_| anyhow!("request has no input stream"))?;
+        output_stream.write(request.body().as_ref())?;
+        drop(output_stream);
+
+        let response_fut = outgoing_handler::handle(request_wasi, None)?;
+        OutgoingBody::finish(request_body, None)?;
+
+        let response_wasi = match response_fut.get() {
+            Some(result) => result.map_err(|_| anyhow!("response already taken"))?,
+            None => {
+                let pollable = response_fut.subscribe();
+                pollable.block();
+                response_fut
+                    .get()
+                    .ok_or_else(|| anyhow!("response available"))?
+                    .map_err(|_| anyhow!("response already taken"))?
+            }
+        }?;
+
+        let mut response_builder = Response::builder();
+        response_builder =
+            response_builder.status(http::StatusCode::from_u16(response_wasi.status())?);
+
+        for (header, values) in response_wasi.headers().entries() {
+            response_builder = response_builder.header(header, values);
+        }
+
+        let body_wasi = response_wasi
+            .consume()
+            .map_err(|()| anyhow!("response has no body stream"))?;
+
+        let input_stream = body_wasi
+            .stream()
+            .map_err(|()| anyhow!("response body has no stream"))?;
+        let input_stream_pollable = input_stream.subscribe();
+
+        let mut body = Vec::new();
+        loop {
+            input_stream_pollable.block();
+            let mut body_chunk = match input_stream.read(1024 * 1024) {
+                Ok(c) => c,
+                Err(StreamError::Closed) => break,
+                Err(e) => Err(anyhow!("input stream read failed: {e:?}"))?,
+            };
+            if !body_chunk.is_empty() {
+                body.append(&mut body_chunk);
+            }
+        }
+        Ok(response_builder.body(body)?)
+    }
+}
+
+impl<T> TryFrom<&http::Request<T>> for bindings::wasi::http::types::OutgoingRequest {
+    type Error = Error;
+
+    fn try_from(request: &http::Request<T>) -> std::result::Result<Self, Self::Error> {
+        let headers = request.headers().try_into()?;
+        let request_wasi = Self::new(headers);
+
+        let method = request.method().into();
+        let scheme = request.uri().scheme().map(|s| s.into());
+        let authority = request.uri().authority().map(|a| a.as_str());
+        let path_and_query = request.uri().path_and_query().map(|a| a.as_str());
+
+        request_wasi
+            .set_method(&method)
+            .map_err(|_| anyhow!("invalid method"))?;
+        request_wasi
+            .set_scheme(scheme.as_ref())
+            .map_err(|_| anyhow!("invalid scheme"))?;
+        request_wasi
+            .set_authority(authority)
+            .map_err(|_| anyhow!("invalid authority"))?;
+        request_wasi
+            .set_path_with_query(path_and_query)
+            .map_err(|_| anyhow!("invalid path_and_query"))?;
+
+        Ok(request_wasi)
+    }
+}
+
+impl From<&http::Method> for bindings::wasi::http::types::Method {
+    fn from(value: &http::Method) -> Self {
+        match value.as_str() {
+            "OPTIONS" => Self::Options,
+            "GET" => Self::Get,
+            "POST" => Self::Post,
+            "PUT" => Self::Put,
+            "DELETE" => Self::Delete,
+            "HEAD" => Self::Head,
+            "TRACE" => Self::Trace,
+            "CONNECT" => Self::Connect,
+            "PATCH" => Self::Patch,
+            other => Self::Other(other.to_string()),
+        }
+    }
+}
+
+impl From<&http::uri::Scheme> for bindings::wasi::http::types::Scheme {
+    fn from(value: &http::uri::Scheme) -> Self {
+        match value.as_str() {
+            "https" | "HTTPS" => Self::Https,
+            _ => Self::Http,
+        }
+    }
+}
+
+impl TryFrom<&http::HeaderMap> for bindings::wasi::http::types::Headers {
+    type Error = bindings::wasi::http::types::HeaderError;
+
+    fn try_from(value: &http::HeaderMap) -> std::result::Result<Self, Self::Error> {
+        let headers = bindings::wasi::http::types::Headers::new();
+        for key in value.keys() {
+            let all: Vec<Vec<u8>> = value
+                .get_all(key)
+                .iter()
+                .flat_map(|v| v.to_str().ok())
+                .map(|v| v.as_bytes().to_vec())
+                .collect();
+            let key: String = key.to_string();
+            headers.set(&key, &all)?;
+        }
+        Ok(headers)
+    }
 }


### PR DESCRIPTION
All generated types are hidden now. We only expose re-exports from [http](https://docs.rs/http/latest/http/) crate and new `send` function:
```rust
pub fn send(request: Request) -> anyhow::Result<Response>
```
http crate is chosen for HTTP protocol primitives as it is de-factor a standard in Rust ecosystem. 

This is an example of usage inside the component code:
```rust
let request = HttpRequest::builder()
     .uri(url)
     .method(Method::POST)
     .header("Custom", "Custom")
     .body("{\"body\":\"some\"}")
     .map_err(|e| e.to_string())?;
let response = send(request).map_err(|e| e.to_string())?;
```